### PR TITLE
Add leader board functionality in to main page

### DIFF
--- a/ClientApp/src/components/NavMenu.js
+++ b/ClientApp/src/components/NavMenu.js
@@ -41,6 +41,9 @@ export class NavMenu extends Component {
                   <NavLink tag={Link} className="text-dark" to="/team-scoreboard">Team</NavLink>
                 </NavItem>
                 <NavItem>
+                  <NavLink tag={Link} className="text-dark" to="/scoreboard">Leaderboard</NavLink>
+                </NavItem>
+                <NavItem>
                   <SettingsMenu />
                 </NavItem>
               </ul>

--- a/ClientApp/src/components/ScoreBoard.js
+++ b/ClientApp/src/components/ScoreBoard.js
@@ -1,53 +1,57 @@
 import React, { Component } from 'react';
 import ApiHelper from './ApiHelper';
+import * as moment from 'moment';
 
 export class ScoreBoard extends Component {
   static displayName = ScoreBoard.name;
 
   constructor (props) {
     super(props);
-    this.state = { forecasts: [], loading: true };
-    /*
+    this.state = {
+      scores: [],
+      dateOfLeaderboard : null,
+      loading: true
+    };
     this.apiHelper = new ApiHelper();
-    var query = `{"query" : "{ leaderBoard{teamScores { teamId, teamName, teamStepCount } }}"}`
+    var query = `{"query" : "{ leaderBoard{ dateOfLeaderboard, teamScores { teamId, teamName } }}"}`
     this.apiHelper.GraphQlApiHelper(query)
     .then(data => {
-        this.setState({ forecasts: data.leaderBoard.teamScores, loading: false });
+        this.setState({ dateOfLeaderboard: data.leaderBoard.dateOfLeaderboard, scores: data.leaderBoard.teamScores, loading: false });
     })
-    */
   }
 
-  static renderForecastsTable (forecasts) {
-    return (
-      <table className='table table-striped'>
-        <thead>
-          <tr>
-            <th></th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {forecasts.map(forecast =>
-            <tr key={forecast.teamId}>
-              <td>{forecast.teamName}</td>
-              <td>{forecast.teamStepCount}</td>
+  static renderScoreBoard (date, scores) {
+    var dateOfScores = moment(date).format('Do MMM')
+      return(
+      <div>
+        <h3>Updated every Monday<span style={{ fontStyle: "italic", fontSize: "16px" }}> Any new steps added for previous weeks will be included</span> </h3>
+        <table className='table table-striped' style={{ textAlign : "center", fontSize: "24px" }} >
+          <thead>
+            <tr>
+              <th>Teams Step Counts until { dateOfScores }</th>
             </tr>
-          )}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {scores.map(score =>
+              <tr key={score.teamId}>
+                <td>{score.teamName}</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     );
   }
 
   render () {
-    let contents = <p><em>Loading...</em></p>
-    /*this.state.loading
+    let contents =
+    this.state.loading
       ? <p><em>Loading...</em></p>
-      : ScoreBoard.renderForecastsTable(this.state.forecasts);
-      */
+      : ScoreBoard.renderScoreBoard(this.state.dateOfLeaderboard, this.state.scores);
 
     return (
       <div>
-        <h2>Latest Scores</h2>
+        <h2>Leader Board</h2>
         {contents}
       </div>
     );

--- a/DataModels/LeaderBoard.cs
+++ b/DataModels/LeaderBoard.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using GraphQL.Types;
 using Model;
@@ -7,6 +8,7 @@ namespace StepChallenge.DataModels
     public class LeaderBoard
     {
         public List<TeamScores> TeamScores { get; set; }
+        public DateTimeOffset DateOfLeaderboard { get; set; }
         
     }
 }

--- a/Model/GraphQL/LeaderBoardType.cs
+++ b/Model/GraphQL/LeaderBoardType.cs
@@ -10,7 +10,9 @@ namespace Model.GraphQL
             Name = "LeaderBoard";
             
             Field(x => x.TeamScores , type: typeof(ListGraphType<TeamScoreType>)).Description("The users steps");
-            
+            Field(x => x.DateOfLeaderboard, type: typeof(DateTimeOffsetGraphType))
+                .Description("The date the scores are taken until");
+
         }
         
     }

--- a/Query/StepChallengeQuery.cs
+++ b/Query/StepChallengeQuery.cs
@@ -111,13 +111,22 @@ namespace StepChallenge.Query
                 {
                     var leaderBoard = new LeaderBoard();
 
-                    var teamSteps = db.Team
-                        .Select(t => new TeamScores
-                        {
-                            TeamId = t.TeamId,
-                            TeamName = t.TeamName,
-                            TeamStepCount = t.Participants.Sum(u => u.Steps.Sum(s => s.StepCount))
-                        }).ToList();
+                    DateTime thisWeek = DateTime.Now;
+                    DateTime thisMonday = stepsService.StartOfWeek(thisWeek, DayOfWeek.Monday);
+
+                    leaderBoard.DateOfLeaderboard = thisMonday;
+
+                    var sortedTeams = db.Team
+                        .Where(t => t.Participants.Any(p => p.Steps.Any(s => s.DateOfSteps > startDate && s.DateOfSteps < thisMonday ))
+                            || t.Participants.All(p => p.Steps.All(s => s.StepCount == 0)))
+                        .OrderByDescending(t => t.Participants.Sum(u => u.Steps.Sum(s => s.StepCount)))
+                        .ToList();
+
+                    var teamSteps = sortedTeams.Select(t => new TeamScores
+                    {
+                        TeamId = t.TeamId,
+                        TeamName = t.TeamName
+                    }).ToList();
 
                     leaderBoard.TeamScores = teamSteps;
 

--- a/Services/StepsService.cs
+++ b/Services/StepsService.cs
@@ -101,7 +101,7 @@ namespace StepChallenge.Services
             return days;
         }
 
-        private static DateTime StartOfWeek(DateTime dt, DayOfWeek startOfWeek)
+        public DateTime StartOfWeek(DateTime dt, DayOfWeek startOfWeek)
         {
             int diff = (7 + (dt.DayOfWeek - startOfWeek)) % 7;
             return dt.AddDays(-1 * diff).Date;


### PR DESCRIPTION
- Refactor existing functionality to never return the teams total step
counts
- Only update the leaderboard weekly, not in real time
- Get the date the leaderboard runs up until