### PR TITLE
Increase the `MaxFailedAccessAttempts` for login attempts

### DIFF
--- a/StepChallenge/Startup.cs
+++ b/StepChallenge/Startup.cs
@@ -95,7 +95,7 @@ namespace StepChallenge
 
                 // Lockout settings.
                 options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(10);
-                        options.Lockout.MaxFailedAccessAttempts = 5;
+                        options.Lockout.MaxFailedAccessAttempts = 100;
                         options.Lockout.AllowedForNewUsers = true;
 
                 // User settings.


### PR DESCRIPTION
Increased the access attempts limit to 100 to stop people locking their accounts so easily