### PR TITLE
Added total steps to leaderboard even if team steps are disabled

### DIFF
--- a/StepChallenge.Tests/LeaderboardTests.cs
+++ b/StepChallenge.Tests/LeaderboardTests.cs
@@ -56,6 +56,19 @@ namespace StepChallenge.Tests
         }
 
         [Test]
+        public void Test_StepsOnlyCountedToLatestMonday_Total()
+        {
+            var teams = TestData.GetTeams_StepsOverLeadBoardDate();
+            var stepsService = new StepsService(GetMockContext());
+
+            var total = stepsService.GetTotalSteps(teams, DateOfFirstWeek, StartDate, 3);
+
+            const int expectedTotalSteps = ((10*3)+(20*3)+(30*3))*3;
+            
+            Assert.AreEqual(expectedTotalSteps, total, $"Expected TotalStepCount {expectedTotalSteps} but got {total} instead");
+        }
+
+        [Test]
         public void Test_TeamsWithLessParticipants_GetAnExtraAveragedPerson()
         {
             var teams = TestData.GetTeams_OneLessParticipantInTeamOne();

--- a/StepChallenge/ClientApp/src/components/ScoreBoard.js
+++ b/StepChallenge/ClientApp/src/components/ScoreBoard.js
@@ -55,23 +55,23 @@ export class ScoreBoard extends Component {
                 :
                 scores.map(score =>
                     <tr key={score.teamId}>
-                        <td width="100%">{score.teamName}</td>
+                        <td colSpan="2" width="100%">{score.teamName}</td>
                     </tr>
                 );
-            var colSpan = showLeaderBoardStepCounts ? 2 : 1;
-            var total = showLeaderBoardStepCounts ? (
+
+            var total = (
                 <tr>
                     <td width="50%">Total steps</td>
                     <td width="50%">{totalSteps}</td>
                 </tr>
-            ) : null;
+            );
             return(
                 <div>
                     <h3>Updated every Monday<span style={{ fontStyle: "italic", fontSize: "16px" }}> Any new steps added for previous weeks will be included</span> </h3>
                     <table className='table table-striped' style={{ textAlign : "center", fontSize: "24px" }} >
                         <thead>
                             <tr>
-                                <th colSpan={colSpan} >Teams Step Counts until { dateOfScores }</th>
+                                <th colSpan="2" >Teams Step Counts until { dateOfScores }</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
Total steps is now displayed at the bottom of the leaderboard even if team steps are disabled. Added a test to make sure that the count is only up to the last monday in the same way as the rest of the totals are calculated