### PR TITLE
New Highest Stepper property on team scoreboard

### DIFF
--- a/StepChallenge.Tests/TeamScoreboardTests.cs
+++ b/StepChallenge.Tests/TeamScoreboardTests.cs
@@ -60,7 +60,71 @@ namespace StepChallenge.Tests
             
             Assert.IsFalse(resultFirstParticipantStepsStatus, $"Expected participant to have step status of False but got {resultFirstParticipantStepsStatus}"); 
         }
-        
+
+        /// <summary>
+        /// Tests that if a participant has the most steps, they are returned as the highest stepper
+        /// </summary>
+        [Test]
+        public void Test_TeamMembersStepStatus_ParticipantHasHighestScore()
+        {
+            var team = TestData.CreateTeamWithHighestStepper();
+
+            var teamService = new TeamService(GetMockStepContext(team));
+            var result = teamService.GetTeamScoreBoard(1);
+
+            var actual = false;
+            var participant = result.First().ParticipantsStepsStatus.SingleOrDefault(p => p.ParticipantId == 1);
+            if (participant != null)
+            {
+                actual = participant.ParticipantHighestStepper;
+            }
+
+            Assert.IsTrue(actual, $"Expected participant to have highest step status of True but got {actual}");
+        }
+
+        /// <summary>
+        /// Tests that if two participants have the most steps, they are both returned as highest stepper set to true
+        /// </summary>
+        [Test]
+        public void Test_TeamMembersStepStatus_ParticipantHasHighestScoreIfStepsAreSame()
+        {
+            var team = TestData.CreateTeamWithHighestStepper();
+            team.Participants.ElementAt(1).Steps.First().StepCount = team.Participants.ElementAt(0).Steps.First().StepCount;
+
+            var teamService = new TeamService(GetMockStepContext(team));
+            var result = teamService.GetTeamScoreBoard(1);
+
+            var actualOne = false;
+            var actualTwo = false;
+
+            var participantOne = result.First().ParticipantsStepsStatus.SingleOrDefault(p => p.ParticipantId == 1);
+            var participantTwo = result.First().ParticipantsStepsStatus.SingleOrDefault(p => p.ParticipantId == 1);
+            if (participantOne != null && participantTwo != null)
+            {
+                actualOne = participantOne.ParticipantHighestStepper;
+                actualTwo = participantTwo.ParticipantHighestStepper;
+            }
+
+            Assert.IsTrue(actualOne && actualTwo, $"Expected participants to both have highest step status of True but got {actualOne} & {actualTwo}");
+        }
+
+        /// <summary>
+        /// Tests that if all participants have zero steps, there is no highest stepper
+        /// </summary>
+        [Test]
+        public void Test_TeamMembersStepStatus_ParticipantsWithZeroStepsAreHighestStepper()
+        {
+            var team = TestData.CreateTeamWithHighestStepper();
+            team.Participants.ElementAt(0).Steps.First().StepCount = 0;
+            team.Participants.ElementAt(1).Steps.First().StepCount = 0;
+            team.Participants.ElementAt(2).Steps.First().StepCount = 0;
+
+            var teamService = new TeamService(GetMockStepContext(team));
+            var result = teamService.GetTeamScoreBoard(1);
+
+            Assert.IsTrue(result.All(r => r.ParticipantsStepsStatus.All(s => s.ParticipantHighestStepper == false)), $"Expected all participants to have highest step status of False but got True"); 
+        }
+
         private StepContext GetMockStepContext(Team team)
         {
             var teamSteps = new List<Steps>();

--- a/StepChallenge.Tests/TeamTests.Data.cs
+++ b/StepChallenge.Tests/TeamTests.Data.cs
@@ -88,6 +88,40 @@ namespace StepChallenge.Tests
             };
         }
 
+        public static Team CreateTeamWithHighestStepper()
+        {
+            return new Team
+            {
+                TeamId = 1,
+                TeamName = "Team_1",
+                NumberOfParticipants = 3,
+                Participants = new List<Participant>
+                {
+                    new Participant
+                    {
+                        ParticipantName = "B_ParticipantNameOne",
+                        ParticipantId = 1,
+                        Steps = CreateSteps(10, 1, StartDate),
+                        TeamId = 1,
+                    },
+                    new Participant
+                    {
+                        ParticipantName = "A_ParticipantNameTwo",
+                        ParticipantId = 2,
+                        Steps = CreateSteps(5, 2, StartDate),
+                        TeamId = 1,
+                    },
+                    new Participant
+                    {
+                        ParticipantName = "C_ParticipantNameThree",
+                        ParticipantId = 3,
+                        Steps = CreateSteps(1, 3, StartDate),
+                        TeamId = 1,
+                    },
+                }
+            };
+        }
+
         private static IQueryable<Team> CreateThreeTeams()
         {
             return (new List<Team>

--- a/StepChallenge/ClientApp/src/App.css
+++ b/StepChallenge/ClientApp/src/App.css
@@ -13,3 +13,8 @@
   font-size: 0.55em;
   text-align: center;
   font-weight: 700; }
+
+.goldStar {
+  border: "1px solid red";
+  text-decoration: underline;
+}

--- a/StepChallenge/ClientApp/src/components/TeamScoreboard.js
+++ b/StepChallenge/ClientApp/src/components/TeamScoreboard.js
@@ -8,7 +8,7 @@ async function loadUserSteps(id) {
   var apiHelper = new ApiHelper()
   var query = `{"query": "query teamQuery( $teamId : ID! )
      { teamSteps( teamId : $teamId )
-        {stepCount, dateOfSteps, participantsStepsStatus { participantName, participantAddedStepCount} }, 
+        {stepCount, dateOfSteps, participantsStepsStatus { participantName, participantAddedStepCount, participantHighestStepper} }, 
         team (teamId: $teamId )
         {teamName, numberOfParticipants, participants { participantName }}
       } ",

--- a/StepChallenge/ClientApp/src/components/TeamStep.js
+++ b/StepChallenge/ClientApp/src/components/TeamStep.js
@@ -33,12 +33,14 @@ class TeamStep extends Component {
       var status = {
         name : "User not registered yet",
         initials: "-",
-        steps: false
+        steps: false,
+        highestStepper: false
       }
       if(this.state.participantsStatus[i] != null ){
         status.name = this.state.participantsStatus[i].participantName
         status.initials = this.state.participantsStatus[i].participantName.charAt(0).toUpperCase()
         status.steps = this.state.participantsStatus[i].participantAddedStepCount
+        status.highestStepper = this.state.participantsStatus[i].participantHighestStepper
       }
         info[i] = status
     }
@@ -50,13 +52,12 @@ class TeamStep extends Component {
         <br/>
          <div style={{"width":"100%"}}>
           {info.map(s =>
-            <span title={this.state.steps != 0 ? s.name : "no steps counted"} className="statusInfo" style={ s.steps ? infoDone : this.state.steps != 0 ? infoMissing : null}>{s.initials}</span>
+            <span title={this.state.steps != 0 ? s.name + (s.highestStepper ? " - well done on being top stepper!" : "") : "no steps counted"} className={s.highestStepper == true ? "goldStar statusInfo" : "statusInfo"} style={  s.steps ? infoDone : this.state.steps != 0 ? infoMissing : null}>{s.initials}</span>
           )}
         </div>
       </div>
     )
   }
 }
-
 
 export default TeamStep;

--- a/StepChallenge/DataModels/TeamScoreBoard.cs
+++ b/StepChallenge/DataModels/TeamScoreBoard.cs
@@ -16,5 +16,7 @@ namespace StepChallenge.DataModels
         public string ParticipantName { get; set; }
         public int ParticipantId { get; set; }
         public bool ParticipantAddedStepCount { get; set; }
+        public int ParticipantStepCount { get; set; }
+        public bool ParticipantHighestStepper { get; set; }
     }
 }

--- a/StepChallenge/Model/GraphQL/ParticipantStepStatus.cs
+++ b/StepChallenge/Model/GraphQL/ParticipantStepStatus.cs
@@ -12,6 +12,7 @@ namespace Model.GraphQL
 
             Field(x => x.ParticipantName, type: typeof(StringGraphType)).Description("The Date of the step count");
             Field(x => x.ParticipantAddedStepCount, type: typeof(BooleanGraphType)).Description("If the participant has filled in their steps or not");
+            Field(x => x.ParticipantHighestStepper, type: typeof(BooleanGraphType)).Description("Participants with the highest step count will be set to true");
         }
 
     }

--- a/StepChallenge/Services/StepsService.cs
+++ b/StepChallenge/Services/StepsService.cs
@@ -99,7 +99,7 @@ namespace StepChallenge.Services
                 {
                     TeamId = t.TeamId,
                     TeamName = t.TeamName,
-                    NumberOfParticipants = t.NumberOfParticipants, //TODO - need to know how many are in a team, if participants haven't registered yet then we can't rely on counting all participants
+                    NumberOfParticipants = t.NumberOfParticipants,
                     TeamStepCount = t.Participants.Sum(p => p.Steps
                         .Where(s => s.DateOfSteps >= startDate && s.DateOfSteps < thisMonday
                                     || t.Participants.All(u => u.Steps.All(x => x.StepCount == 0)))
@@ -107,6 +107,7 @@ namespace StepChallenge.Services
                 })
                 .ToList();
 
+            // add a pretend participant with averaged steps to teams with less participants
             foreach (var teamScore in sortedTeams.Where(t => t.NumberOfParticipants != averageTeamSize && t.NumberOfParticipants != 0))
             {
                 teamScore.TeamStepCount = ((teamScore.TeamStepCount / teamScore.NumberOfParticipants) *

--- a/StepChallenge/Services/TeamService.cs
+++ b/StepChallenge/Services/TeamService.cs
@@ -54,13 +54,28 @@ namespace StepChallenge.Services
 
             foreach (var teamStep in teamSteps)
             {
-                teamStep.ParticipantsStepsStatus = participants
+                var stepsStatuses = participants
                     .Select(p => new ParticipantsStepsStatus
                     {
                         ParticipantName = p.ParticipantName,
                         ParticipantId = p.ParticipantId,
-                        ParticipantAddedStepCount = p.Steps.Any(ps => ps.DateOfSteps == teamStep.DateOfSteps && ps.StepCount != 0)
+                        ParticipantAddedStepCount =
+                            p.Steps.Any(ps => ps.DateOfSteps == teamStep.DateOfSteps && ps.StepCount != 0),
+                        ParticipantStepCount = p.Steps.Where(ps => ps.DateOfSteps == teamStep.DateOfSteps).Sum(ps => ps.StepCount),
                     })
+                    .OrderByDescending(p => p.ParticipantStepCount)
+                    .ToList();
+
+                var highest = stepsStatuses.First().ParticipantStepCount;
+                if (highest != 0)
+                {
+                    foreach (var stepStatus in stepsStatuses.Where(p => p.ParticipantStepCount == highest))
+                    {
+                        stepStatus.ParticipantHighestStepper = true;
+                    }
+                }
+
+                teamStep.ParticipantsStepsStatus = stepsStatuses
                     .OrderBy(p => p.ParticipantName)
                     .ToList();
             }


### PR DESCRIPTION
- So a team can see who is their highest stepper for the day, added a
new bool property onto the team score board model
- The participant or participants with the highest scores get the new
`ParticipantHighestStepper` flag set to true
- On the front end, add a new style class which underlines their
initial and add a well done message into the title text
- Closes issue #79

![image](https://user-images.githubusercontent.com/14791708/68250511-f651ea00-0018-11ea-85f5-ba76062b38d3.png)
